### PR TITLE
service: add PersistentFlags() and LocalFlags() shortcuts

### DIFF
--- a/pkg/service/cmd.go
+++ b/pkg/service/cmd.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kardianos/service"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // CmdName returns the arg[0] of this execution
@@ -48,6 +49,16 @@ func (s *Service) Command() *cobra.Command {
 // AddCommand adds an extra interactive command to the tool
 func (s *Service) AddCommand(cmd *cobra.Command) {
 	s.cmd.AddCommand(cmd)
+}
+
+// PersistentFlags returns the flags also passed to sub-commands
+func (s *Service) PersistentFlags() *pflag.FlagSet {
+	return s.cmd.PersistentFlags()
+}
+
+// LocalFlags returns the flags only used for the root command
+func (s *Service) LocalFlags() *pflag.FlagSet {
+	return s.cmd.LocalFlags()
 }
 
 // OnInitialize sets functions to be executed right after

--- a/pkg/service/go.mod
+++ b/pkg/service/go.mod
@@ -5,10 +5,10 @@ go 1.20
 require (
 	github.com/kardianos/service v1.2.2
 	github.com/spf13/cobra v1.7.0
+	github.com/spf13/pflag v1.0.5
 )
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 )


### PR DESCRIPTION
to reach cobra.Command's flags without going through Command()