### PR TITLE
revive: allow lines up to 120 characters

### DIFF
--- a/pkg/tools/revive.toml
+++ b/pkg/tools/revive.toml
@@ -17,7 +17,7 @@ enableAllRules = true
 [rule.cyclomatic]
   arguments = [10]
 [rule.line-length-limit]
-  arguments = [100]
+  arguments = [120]
   severity = "warning"
 [rule.comment-spacings]
   severity = "warning"


### PR DESCRIPTION
structtags can be quite long on config structs.

this is the same value used by `golang-lint`