### PR TITLE
config: refactor using the latest darvaza.org/x/config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	darvaza.org/slog/handlers/filter v0.4.9
 	darvaza.org/slog/handlers/zap v0.4.1
 	darvaza.org/slog/handlers/zerolog v0.4.9
-	darvaza.org/x/config v0.2.9
+	darvaza.org/x/config v0.3.1
 	darvaza.org/x/net v0.1.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ darvaza.org/slog/handlers/zerolog v0.4.9 h1:08FjRnwRGtJsLLBnbgxVorb/bkgm5QEM/LXD
 darvaza.org/slog/handlers/zerolog v0.4.9/go.mod h1:PZYfx6eOxQfD+cXJQp52iwKgcD30QVYHoXxOCojAOdw=
 darvaza.org/x/config v0.2.9 h1:9Fivua+hPgCy5MbBM1b4E38ACCYY4YSmbap4U8uDzrY=
 darvaza.org/x/config v0.2.9/go.mod h1:TB6lz0LotDwdp0s5NgfjEqmbxL2BQBV3VGHIrxEq4Y8=
+darvaza.org/x/config v0.3.1 h1:hnXV9FSTOWWiOOMyflPbS9vKpcBG8j2QaMCNp2R78JU=
+darvaza.org/x/config v0.3.1/go.mod h1:0i88K9P/m0lKRoHqz5szwLB0m2skj23daIgJwKxURvw=
 darvaza.org/x/net v0.1.1 h1:8VjQfk4K8IfKX1s03q3uG2FRL9lb3kghlX9qj3aX98M=
 darvaza.org/x/net v0.1.1/go.mod h1:GA3x5frLGnQiOU7xm341b9jXXgUg/2Q1hTniOzLLO+8=
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,8 +2,6 @@
 package config
 
 import (
-	"os"
-
 	"darvaza.org/x/config"
 	"darvaza.org/x/config/expand"
 )
@@ -27,17 +25,12 @@ func LoadFile[T any](filename string, v *T,
 	}
 
 	if dec == nil {
-		return ErrUnknownFormat
+		return config.NewPathError(filename, "decode", ErrUnknownFormat)
 	}
 
 	if err := dec.Decode(data, v); err != nil {
 		// failed to decode
-		err = &os.PathError{
-			Path: filename,
-			Op:   "decode",
-			Err:  err,
-		}
-		return err
+		return config.NewPathError(filename, "decode", err)
 	}
 
 	return loadFileDecoded[T](filename, v, options)
@@ -46,23 +39,13 @@ func LoadFile[T any](filename string, v *T,
 func loadFileDecoded[T any](filename string, v *T, options []func(*T) error) error {
 	for _, opt := range options {
 		if err := opt(v); err != nil {
-			err = &os.PathError{
-				Path: filename,
-				Op:   "init",
-				Err:  err,
-			}
-			return err
+			return config.NewPathError(filename, "init", err)
 		}
 	}
 
 	if err := config.Prepare(v); err != nil {
 		// failed to validate
-		err = &os.PathError{
-			Path: filename,
-			Op:   "validate",
-			Err:  err,
-		}
-		return err
+		return config.NewPathError(filename, "validate", err)
 	}
 
 	// success

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,7 +10,7 @@ import (
 // filling gaps and validating its content.
 // LoadFile uses the file extension to determine the format.
 func LoadFile[T any](filename string, v *T,
-	options ...func(*T) error) error {
+	options ...config.Option[T]) error {
 	//
 	data, err := expand.FromFile(filename, nil)
 	if err != nil {
@@ -36,7 +36,7 @@ func LoadFile[T any](filename string, v *T,
 	return loadFileDecoded[T](filename, v, options)
 }
 
-func loadFileDecoded[T any](filename string, v *T, options []func(*T) error) error {
+func loadFileDecoded[T any](filename string, v *T, options []config.Option[T]) error {
 	for _, opt := range options {
 		if err := opt(v); err != nil {
 			return config.NewPathError(filename, "init", err)
@@ -54,7 +54,7 @@ func loadFileDecoded[T any](filename string, v *T, options []func(*T) error) err
 
 // New creates a new config, applying the initialization functions,
 // filling gaps and validating its content.
-func New[T any](options ...func(*T) error) (*T, error) {
+func New[T any](options ...config.Option[T]) (*T, error) {
 	v := new(T)
 	if err := loadFileDecoded("", v, options); err != nil {
 		return nil, err

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -8,15 +8,13 @@ import (
 	"github.com/spf13/pflag"
 
 	"darvaza.org/x/config"
+	"darvaza.org/x/config/appdir"
 )
 
 var (
 	// CmdName is the base name of default config files if none is
 	// specified on the [Loader]
 	CmdName = filepath.Base(os.Args[0])
-	// DefaultDirectories is the list of directories to test when trying
-	// to find a config file.
-	DefaultDirectories = []string{".", "/etc", "/etc/" + CmdName}
 	// DefaultExtensions is the list of extensions to test when trying
 	// to find a config file.
 	DefaultExtensions = []string{"conf", "json", "toml", "yaml", "yml"}
@@ -46,7 +44,7 @@ func (l *Loader[T]) SetDefaults() {
 	}
 
 	if len(l.Directories) == 0 {
-		l.Directories = DefaultDirectories
+		l.Directories = appdir.AllConfigDir(CmdName)
 	}
 
 	if len(l.Extensions) == 0 {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/pflag"
+
+	"darvaza.org/x/config"
 )
 
 var (
@@ -54,7 +56,7 @@ func (l *Loader[T]) SetDefaults() {
 
 // NewFromFile loads a config file by name, followed by initialization, filling gaps,
 // and validation.
-func (l *Loader[T]) NewFromFile(configFile string, options ...func(*T) error) (*T, error) {
+func (l *Loader[T]) NewFromFile(configFile string, options ...config.Option[T]) (*T, error) {
 	l.last = configFile
 
 	cfg := new(T)
@@ -69,7 +71,7 @@ func (l *Loader[T]) NewFromFile(configFile string, options ...func(*T) error) (*
 // NewFromFlag uses a cobra Flag for the config file name. if not specifies
 // the known locations will be tried, and if all fails, it will create a
 // default one.
-func (l *Loader[T]) NewFromFlag(flag *pflag.Flag, options ...func(*T) error) (*T, error) {
+func (l *Loader[T]) NewFromFlag(flag *pflag.Flag, options ...config.Option[T]) (*T, error) {
 	if flag.Changed {
 		// given
 		configFile := flag.Value.String()
@@ -81,7 +83,7 @@ func (l *Loader[T]) NewFromFlag(flag *pflag.Flag, options ...func(*T) error) (*T
 
 // NewFromKnownLocations scans locations specified in the [Loader] for a config file,
 // if not possible it will create a default one.
-func (l *Loader[T]) NewFromKnownLocations(options ...func(*T) error) (*T, error) {
+func (l *Loader[T]) NewFromKnownLocations(options ...config.Option[T]) (*T, error) {
 	var files []string
 
 	l.SetDefaults()


### PR DESCRIPTION
## **Type**
Enhancement


___

## **Description**
- This PR includes a significant refactoring of the `config.go` and `loader.go` files in the `pkg/config` directory, to use the latest version of `darvaza.org/x/config`.
- The `LoadFile`, `loadFileDecoded`, and `New` functions in `config.go` have been updated to use `config.Option[T]` instead of `func(*T) error`.
- Error handling in these functions has been refactored to use `config.NewPathError` instead of `os.PathError`.
- In `loader.go`, the `Loader` struct and related functions have been refactored in a similar manner.
- The `DefaultDirectories` variable has been replaced with a call to `appdir.AllConfigDir(CmdName)`.
- A new function, `NewDecoderFactory`, has been added to return a `config.Decoder` factory.
- The `go.mod` and `go.sum` files have been updated due to the version update of `darvaza.org/x/config`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Refactor config.go to use latest darvaza.org/x/config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/config/config.go

- Refactored `LoadFile` and `loadFileDecoded` functions to use <br>  `config.Option[T]` instead of `func(*T) error`.<br> - Replaced `os.PathError` with `config.NewPathError` for error <br>  handling.<br> - Updated `New` function to use `config.Option[T]` instead of `func(*T) `<br>  `error`.

    </details>
  </td>
  <td><a href="https://github.com/darvaza-proxy/sidecar/pull/54/files#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5">+7/-24</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>loader.go</strong><dd><code>Refactor loader.go to use latest darvaza.org/x/config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/config/loader.go

- Refactored `Loader` struct and related functions to use <br>  `config.Option[T]` instead of `func(*T) error`.<br> - Replaced `DefaultDirectories` with a call to <br>  `appdir.AllConfigDir(CmdName)`.<br> - Added `NewDecoderFactory` function to return a `config.Decoder` <br>  factory.

    </details>
  </td>
  <td><a href="https://github.com/darvaza-proxy/sidecar/pull/54/files#diff-85669ee11cc99bd32ebc4181b5bcde75983b36d59e88507970cae97e06c1eb4d">+57/-39</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Update darvaza.org/x/config version in go.mod</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
go.mod

- Updated the version of `darvaza.org/x/config` from `v0.2.9` to <br>  `v0.3.1`.

    </details>
  </td>
  <td><a href="https://github.com/darvaza-proxy/sidecar/pull/54/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>go.sum</strong><dd><code>Update darvaza.org/x/config checksums in go.sum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
go.sum

- Updated the checksums for `darvaza.org/x/config` due to version <br>  update.

    </details>
  </td>
  <td><a href="https://github.com/darvaza-proxy/sidecar/pull/54/files#diff-3295df7234525439d778f1b282d146a4f1ff6b415248aaac074e8042d9f42d63">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
