### PR TITLE
fix(sidecar): httpserver: use QUIC instead of Quic [BREAKING]

### DIFF
--- a/pkg/sidecar/httpserver/http2.go
+++ b/pkg/sidecar/httpserver/http2.go
@@ -49,8 +49,8 @@ func (srv *Server) NewH2Handler(h http.Handler) http.Handler {
 	// ACME-HTTP-01 handler or 404 for /.well-known/acme-challenge
 	h = AcmeHTTP01Middleware(h, srv.cfg.AcmeHTTP01)
 
-	// Advertise Quic
-	h = srv.QuicHeadersMiddleware(h)
+	// Advertise QUIC
+	h = srv.QUICHeadersMiddleware(h)
 
 	return h
 }

--- a/pkg/sidecar/httpserver/http2c.go
+++ b/pkg/sidecar/httpserver/http2c.go
@@ -42,8 +42,8 @@ func (srv *Server) NewH2CHandler(h http.Handler) http.Handler {
 	// ACME-HTTP-01 handler or 404 for /.well-known/acme-challenge
 	h = AcmeHTTP01Middleware(h, srv.cfg.AcmeHTTP01)
 
-	// Advertise Quic
-	h = srv.QuicHeadersMiddleware(h)
+	// Advertise QUIC
+	h = srv.QUICHeadersMiddleware(h)
 
 	return h
 }

--- a/pkg/sidecar/httpserver/http3.go
+++ b/pkg/sidecar/httpserver/http3.go
@@ -14,20 +14,20 @@ import (
 
 const (
 	// AltSvcHeader is the header label used to advertise
-	// Quic support
+	// QUIC support
 	AltSvcHeader = "Alt-Svc"
 
-	// GrabQuicHeadersRetry indicates how long we wait to
+	// GrabQUICHeadersRetry indicates how long we wait to
 	// grab the generated Alt-Svc header
-	GrabQuicHeadersRetry = 10 * time.Millisecond
+	GrabQUICHeadersRetry = 10 * time.Millisecond
 )
 
-// asQuicEarlyListeners converts a slice of UDP Listeners into QUIC Listeners.
-func (srv *Server) asQuicEarlyListeners(listeners []*net.UDPConn) ([]*quic.EarlyListener, error) {
+// asQUICEarlyListeners converts a slice of UDP Listeners into QUIC Listeners.
+func (srv *Server) asQUICEarlyListeners(listeners []*net.UDPConn) ([]*quic.EarlyListener, error) {
 	var out []*quic.EarlyListener
 
 	if l := len(listeners); l > 0 {
-		cfg := srv.NewQuicConfig()
+		cfg := srv.NewQUICConfig()
 		tlsConf := srv.NewTLSConfig()
 		tlsConf = http3.ConfigureTLSConfig(tlsConf)
 
@@ -74,13 +74,13 @@ func (srv *Server) spawnH3(h http.Handler, listeners []*quic.EarlyListener, grac
 	for _, lsn := range listeners {
 		h3s := srv.NewH3Server(h, lsn.Addr())
 
-		srv.spawnQuic(h3s, lsn, graceful)
+		srv.spawnQUIC(h3s, lsn, graceful)
 	}
 
 	return nil
 }
 
-func (srv *Server) spawnQuic(h3s *http3.Server, lsn *quic.EarlyListener, _ time.Duration) {
+func (srv *Server) spawnQUIC(h3s *http3.Server, lsn *quic.EarlyListener, _ time.Duration) {
 	const proto = "h3"
 
 	addr, ok := core.AddrPort(lsn.Addr())
@@ -102,58 +102,58 @@ func (srv *Server) spawnQuic(h3s *http3.Server, lsn *quic.EarlyListener, _ time.
 	}, nil)
 }
 
-// NewQuicConfig returns the [quic.Config] to be used on the
+// NewQUICConfig returns the [quic.Config] to be used on the
 // [http3.Server].
-func (*Server) NewQuicConfig() *quic.Config {
+func (*Server) NewQUICConfig() *quic.Config {
 	return &quic.Config{}
 }
 
-// SetQuicHeaders appends Quic's Alt-Svc to the [http.Response] headers.
-func (srv *Server) SetQuicHeaders(hdr http.Header) error {
-	if s := srv.getQuicAltSvc(); s != "" {
+// SetQUICHeaders appends QUIC's Alt-Svc to the [http.Response] headers.
+func (srv *Server) SetQUICHeaders(hdr http.Header) error {
+	if s := srv.getQUICAltSvc(); s != "" {
 		hdr[AltSvcHeader] = append(hdr[AltSvcHeader], s)
 	}
 	return http3.ErrNoAltSvcPort
 }
 
-// QuicHeadersMiddleware creates a middleware function
+// QUICHeadersMiddleware creates a middleware function
 // that injects Alt-Svc on the [http.Response] headers.
-func (srv *Server) QuicHeadersMiddleware(next http.Handler) http.Handler {
+func (srv *Server) QUICHeadersMiddleware(next http.Handler) http.Handler {
 	h := func(rw http.ResponseWriter, req *http.Request) {
-		_ = srv.SetQuicHeaders(rw.Header())
+		_ = srv.SetQUICHeaders(rw.Header())
 		next.ServeHTTP(rw, req)
 	}
 
 	return http.HandlerFunc(h)
 }
 
-// grabQuicHeader tries periodically to grab the Alt-Svc headers corresponding
+// grabQUICHeader tries periodically to grab the Alt-Svc headers corresponding
 // to a server until it succeeds or the given context is cancelled.
 func (srv *Server) grabQUICHeaders(ctx context.Context, h3s *http3.Server) error {
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
-		case <-time.After(GrabQuicHeadersRetry):
+		case <-time.After(GrabQUICHeadersRetry):
 			hdr := make(http.Header)
 
 			if err := h3s.SetQUICHeaders(hdr); err == nil {
 				// success
-				srv.appendQuicHeaders(hdr[AltSvcHeader])
+				srv.appendQUICHeaders(hdr[AltSvcHeader])
 				return nil
 			}
 		}
 	}
 }
 
-func (srv *Server) getQuicAltSvc() string {
+func (srv *Server) getQUICAltSvc() string {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
 
 	return srv.quicAltSvc
 }
 
-func (srv *Server) appendQuicHeaders(alts []string) {
+func (srv *Server) appendQUICHeaders(alts []string) {
 	var s []string
 
 	srv.mu.Lock()

--- a/pkg/sidecar/httpserver/server.go
+++ b/pkg/sidecar/httpserver/server.go
@@ -37,7 +37,7 @@ func (srv *Server) Spawn(h http.Handler, wait time.Duration) error {
 		func() error { return srv.prepare() },
 		func() error { return srv.spawnH2C(h, srv.sl.Insecure, graceful) },
 		func() error { return srv.spawnH2(h, srv.sl.Secure, graceful) },
-		func() error { return srv.spawnH3(h, srv.sl.Quic, graceful) },
+		func() error { return srv.spawnH3(h, srv.sl.QUIC, graceful) },
 	} {
 		if err := fn(); err != nil {
 			srv.eg.Cancel(err)

--- a/pkg/sidecar/httpserver/server_listen.go
+++ b/pkg/sidecar/httpserver/server_listen.go
@@ -22,7 +22,7 @@ const (
 type Listeners struct {
 	Secure   []net.Listener
 	Insecure []*net.TCPListener
-	Quic     []*quic.EarlyListener
+	QUIC     []*quic.EarlyListener
 
 	up atomic.Bool
 }
@@ -31,7 +31,7 @@ type Listeners struct {
 func (sl *Listeners) Close() error {
 	closeAll(sl.Secure)
 	closeAll(sl.Insecure)
-	closeAll(sl.Quic)
+	closeAll(sl.QUIC)
 	return nil
 }
 
@@ -84,7 +84,7 @@ func (srv *Server) newListeners(cfg *BindingConfig, bc *bind.Config) (*Listeners
 			return nil, err
 		}
 		sl.Secure = tlsLsn
-		sl.Quic = quicLsn
+		sl.QUIC = quicLsn
 	}
 
 	// HTTP
@@ -113,7 +113,7 @@ func (srv *Server) bindTLS(bc *bind.Config) ([]net.Listener, []*quic.EarlyListen
 
 	tlsLsn := srv.asSecureListeners(tcp)
 
-	quicLsn, err := srv.asQuicEarlyListeners(udp)
+	quicLsn, err := srv.asQUICEarlyListeners(udp)
 	if err != nil {
 		closeAll(tlsLsn)
 		closeAll(udp)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated naming conventions for QUIC-related methods and variables
	- Corrected capitalization of "QUIC" across multiple files
	- Standardized method and variable names for consistency

- **Chores**
	- Refactored code to improve readability and maintain uniform naming conventions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->